### PR TITLE
Transfer form invalid files

### DIFF
--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/forms.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/forms.js
@@ -254,7 +254,8 @@ $(() => {
     /***************************************************************************
      * Dropzone Setup
      **************************************************************************/
-    var issueFiles = []
+    var issueFiles = []    // An array of file names
+    var uploadedFiles = [] // An array of File objects
     var sessionToken = ''
     const csrfToken = getCookie('csrftoken')
 
@@ -302,25 +303,34 @@ $(() => {
         },
         init: function() {
             issueFiles = []
-            dropzoneClosure = this
-            submitButton = document.getElementById("submit-form-btn")
+            uploadedFiles = []
+            sessionToken = ''
+
+            var dropzoneClosure = this
+            var submitButton = document.getElementById("submit-form-btn")
 
             submitButton.addEventListener("click", (event) => {
                 event.preventDefault()
                 event.stopPropagation()
-                clearDropzoneErrors()
 
-                if (dropzoneClosure.getQueuedFiles().length > 0) {
-                    dropzoneClosure.options.autoProcessQueue = true
-                    dropzoneClosure.processQueue()
-                } else {
-                    addDropzoneError('You cannot submit a form without files.')
+                if (issueFiles.length > 0) {
+                    alert('One or more files cannot be uploaded. Remove them before submitting')
                 }
-            });
+                else {
+                    clearDropzoneErrors()
+                    if (dropzoneClosure.getQueuedFiles().length + uploadedFiles.length === 0) {
+                        alert('You cannot submit a form without files. Please choose at least one file')
+                    }
+                    else {
+                        dropzoneClosure.options.autoProcessQueue = true
+                        dropzoneClosure.processQueue()
+                    }
+                }
+            })
 
             // Triggers on non-200 status
             this.on("error", (file, response, xhr) => {
-                if ("verboseError" in response) {
+                if (response.verboseError) {
                     addDropzoneError(response.verboseError)
                 }
                 else {
@@ -331,19 +341,15 @@ $(() => {
                 dropzoneClosure.options.autoProcessQueue = false
             })
 
-            this.on("addedfile", (file) => {
-                clearDropzoneErrors()
-            })
-
             this.on("removedfile", (file) => {
                 // If this file previously caused an issue, remove it from issueFiles
                 issueIndex = issueFiles.indexOf(file.name)
                 if (issueIndex > -1) {
                     issueFiles.splice(issueIndex, 1)
                 }
-
                 if (issueFiles.length === 0) {
                     document.getElementById("submit-form-btn").disabled = false
+                    clearDropzoneErrors()
                 }
             })
 
@@ -351,8 +357,24 @@ $(() => {
                 xhr.setRequestHeader("Upload-Session-Token", sessionToken)
             })
 
-            this.on("successmultiple", (file, response) => {
-                sessionToken = response['upload_session_token']
+            this.on("successmultiple", (files, response) => {
+                if (response.uploadSessionToken) {
+                    sessionToken = response.uploadSessionToken
+                }
+                var invalidFileNames = []
+                for (const issue of response.issues) {
+                    var fileName = issue.file
+                    invalidFileNames.push(fileName)
+                    var fileObj = files.filter(file => { return file.name === fileName })[0]
+                    var errMessage = {'error': issue.error, 'verboseError': issue.verboseError}
+                    dropzoneClosure.emit('error', fileObj, errMessage, null)
+                    console.log(`pushed: ${fileName}`)
+                }
+                for (const file of files) {
+                    if (invalidFileNames && invalidFileNames.indexOf(file.name) === -1) {
+                        uploadedFiles.push(file)
+                    }
+                }
             })
 
             this.on("queuecomplete", () => {
@@ -370,7 +392,7 @@ $(() => {
                         console.error('Could not find any input id matching "session_token" on the page!')
                     }
                 }
-                else {
+                else if (!issueFiles.length === dropzoneClosure.files.length) {
                     alert('There are one or more files that could not be uploaded. Remove these files and try again.')
                 }
             })

--- a/bagitobjecttransfer/recordtransfer/urls.py
+++ b/bagitobjecttransfer/recordtransfer/urls.py
@@ -19,6 +19,8 @@ urlpatterns = [
         ('grouptransfer', forms.GroupTransferForm),
         ('uploadfiles', forms.UploadFilesForm),
         ])), name='transfer'),
+
+    path('transfer/checkfile/', login_required(views.checkfileextension), name='checkfile'),
     path('transfer/uploadfile/', login_required(views.uploadfiles), name='uploadfile'),
     path('transfer/sent/', views.TransferSent.as_view(), name='transfersent'),
 


### PR DESCRIPTION
Closes #7 

The file upload logic has changed to provide more robust uploads that don't fail if one or more files are invalid. There is a new endpoint at `/transfer/checkfiles/` that can be used to check if a file is allowed to be uploaded. In the file drop zone, this endpoint is used to check the name of the file _before_ the user even has a chance to upload it. If the name of the file is invalid, the user will not be able to submit the form, and will need to remove the file from the form before submitting.

Before, the file extension check was completed after the entire file was streamed to the server, which wasted resources.

There is also now a redundant file extension check if the user manages to circumvent the first check.