### PR TITLE
Update docker-compose docs

### DIFF
--- a/bagitobjecttransfer/docker-compose.dev.yml
+++ b/bagitobjecttransfer/docker-compose.dev.yml
@@ -22,8 +22,8 @@ services:
     volumes:
       - ./:/app
       - /tmp:/tmp
-      - ./logs/rqworker.log:/var/log/django-rq/rqworker.log
-      - ./logs/recordtransfer.log:/var/log/django/recordtransfer.log
+      - ./logs/django-rq:/var/log/django-rq
+      - ./logs/django:/var/log/django
     env_file:
       - ./.dockerenv
     environment:
@@ -39,7 +39,7 @@ services:
       - 6379:6379
     volumes:
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
-      - ./logs/redis-server.log:/var/log/redis/redis-server.log
+      - ./logs/redis:/var/log/redis
     environment:
       REDIS_REPLICATION_MODE: master
 

--- a/docs/running/docker.rst
+++ b/docs/running/docker.rst
@@ -11,6 +11,11 @@ the :code:`bagitobjecttransfer` folder. Put these contents in it if it's not alr
 ::
 
     BAG_STORAGE_FOLDER = /app/media/bags
+    ARCHIVIST_EMAIL=<your email address>
+    MYSQL_ROOT_PASSWORD=root-pw
+    MYSQL_DATABASE=records-transfer-db
+    MYSQL_USER=records-user
+    MYSQL_PASSWORD=records-password
 
 
 After ensuring you have a minimal environment file set up, make sure you are in the


### PR DESCRIPTION
Hey @danloveg 

Here is the `.dockerenv` I needed to get the docker-compose setup running. I passed your code along to some other devs I work with and one hit on some of the same problems I hit. I then felt guilty as I just sent them to your docs and forgot to warn them.

I also altered the `docker-compose.dev.yml` to avoid the files as directories problems.

I did get the local development setup working, but I had to run both the django server (`python3 manage.py runserver`) and the django-rq worker (`python3 manage.py rq_worker default`) outside of docker. Inside I had problems with the rq_worker losing its connection and dying (taking the whole container down with it).

This probably should not be needed but I found this way I could connect PyCharm to the one I wanted to trace and see what was happening.