### PR TITLE
Override generateHTML function

### DIFF
--- a/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/widgetconfig.js
+++ b/bagitobjecttransfer/recordtransfer/static/recordtransfer/js/widgetconfig.js
@@ -2,76 +2,38 @@ $(() => {
     /***************************************************************************
      * jQuery Date Picker Setup
      **************************************************************************/
-    function addEstimatedButtonToStartDate(instance) {
-        var buttonPane = $(instance).datepicker("widget")
-        var html = [
-            '<div style="margin-bottom: 5px;">',
-            '    <input id="start_date_is_approximate_mirror" type="checkbox">',
-            '    <label>&nbsp;Date Estimated</label>',
-            '</div>',
-        ].join('\n')
-        buttonPane.append(html)
-        if ($('#id_recorddescription-start_date_is_approximate').prop('checked')) {
-            $('#start_date_is_approximate_mirror').prop('checked', true)
-        }
-        $('#start_date_is_approximate_mirror').on('click', function(event) {
-            checked = $(this).prop('checked')
-            $('#id_recorddescription-start_date_is_approximate').prop('checked', checked)
-        })
+     // Map original function to _old
+    $.datepicker._generateHTML_old = $.datepicker._generateHTML;
+    // Override the function.
+    $.datepicker._generateHTML = function(inst) {
+        var html = this._generateHTML_old(inst);
+        var pickerName = ($('#' + inst.id).hasClass("start_date_picker") ? "start_date" : "end_date");
+        var checkboxName = pickerName + "_is_approximate_mirror";
+        var hiddenName = "id_recorddescription-" + pickerName + "_is_approximate";
+        var hiddenChecked = $('#' + hiddenName).is(':checked');
+        var appendHtml = [
+             '<div style="margin-bottom: 5px;">',
+             '    <input id="' + checkboxName + '" type="checkbox"' +
+             (hiddenChecked ? ' checked="checked"' : "") + '>',
+             '    <label>&nbsp;Date Estimated</label>',
+             '</div>',
+          ].join('\n');
+
+        setTimeout(function() {
+            $('#' + checkboxName).on('click', function(event) {
+                checked = $(this).is(':checked')
+                $('#' + hiddenName).prop('checked', checked)
+            });
+        }, 5);
+        return html + appendHtml;
     }
 
-    function addEstimatedButtonToEndDate(instance) {
-        var buttonPane = $(instance).datepicker("widget")
-        var html = [
-            '<div style="margin-bottom: 5px;">',
-            '    <input id="end_date_is_approximate_mirror" type="checkbox">',
-            '    <label>&nbsp;Date Estimated</label>',
-            '</div>',
-        ].join('\n')
-        buttonPane.append(html)
-        if ($('#id_recorddescription-end_date_is_approximate').prop('checked')) {
-            $('#end_date_is_approximate_mirror').prop('checked', true)
-        }
-        $('#end_date_is_approximate_mirror').on('click', function(event) {
-            checked = $(this).prop('checked')
-            $('#id_recorddescription-end_date_is_approximate').prop('checked', checked)
-        })
-    }
-
-    $('.start_date_picker').datepicker({
+    $('.start_date_picker, .end_date_picker').datepicker({
         dateFormat: "yy-mm-dd",
         changeMonth: true,
         changeYear: true,
         minDate: new Date(1700, 1, 1),
         maxDate: 0,
-        beforeShow: function (input, inst) {
-            setTimeout(function () {
-                addEstimatedButtonToStartDate(input)
-            }, 5)
-        },
-        onChangeMonthYear: function(year, month, inst) {
-            setTimeout(function () {
-                addEstimatedButtonToStartDate(inst)
-            }, 5)
-        },
-    })
-
-    $('.end_date_picker').datepicker({
-        dateFormat:"yy-mm-dd",
-        changeMonth: true,
-        changeYear: true,
-        minDate: new Date(1700, 1, 1),
-        maxDate: 0,
-        beforeShow: function (input, inst) {
-            setTimeout(function () {
-                addEstimatedButtonToEndDate(input)
-            }, 5)
-        },
-        onChangeMonthYear: function(year, month, inst) {
-            setTimeout(function () {
-                addEstimatedButtonToEndDate(inst)
-            }, 5)
-        },
     })
 
     /***************************************************************************


### PR DESCRIPTION
Resolves #19 

It appears that when you [type in a full date](https://github.com/jquery/jquery-ui/blob/32850869d308d5e7c9bf3e3b4d483ea886d373ce/ui/widgets/datepicker.js#L725-L728) the [`_updateDatepicker`](https://github.com/jquery/jquery-ui/blob/32850869d308d5e7c9bf3e3b4d483ea886d373ce/ui/widgets/datepicker.js#L826) function is called, which calls the [`_generateHTML`](https://github.com/jquery/jquery-ui/blob/32850869d308d5e7c9bf3e3b4d483ea886d373ce/ui/widgets/datepicker.js#L1657) function to re-generate the date picker.

The `_generateHTML` just returns a string of the HTML so I override the function, call the original one, create the estimated date checkbox HTML and return both string.

As the `_generateHTML` function is called for all the other events I could remove them. 

But as it is called for all the other events, I had to also dynamically determine which input box we were currently in.
