### PR TITLE
Send emails for certain account changes

### DIFF
--- a/bagitobjecttransfer/bagitobjecttransfer/settings/base.py
+++ b/bagitobjecttransfer/bagitobjecttransfer/settings/base.py
@@ -96,6 +96,10 @@ USE_L10N = True
 
 USE_TZ = True
 
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale')
+]
+
 # django-countries configuration
 # https://github.com/SmileyChris/django-countries
 

--- a/bagitobjecttransfer/recordtransfer/admin.py
+++ b/bagitobjecttransfer/recordtransfer/admin.py
@@ -139,14 +139,14 @@ class CustomUserAdmin(UserAdmin):
         message_list = list()
         if "is_superuser" in changed_data:
             if user.is_superuser:
-                message_list.append("Superuser privileges have been added to your account.")
+                message_list.append(gettext("Superuser privileges have been added to your account."))
             else:
-                message_list.append("Superuser privileges have been removed from your account.")
+                message_list.append(gettext("Superuser privileges have been removed from your account."))
         if "is_staff" in changed_data:
             if user.is_staff:
-                message_list.append("Staff privileges have been added to your account.")
+                message_list.append(gettext("Staff privileges have been added to your account."))
             else:
-                message_list.append("Staff privileges have been removed from your account.")
+                message_list.append(gettext("Staff privileges have been removed from your account."))
         return message_list
 
 

--- a/bagitobjecttransfer/recordtransfer/jobs.py
+++ b/bagitobjecttransfer/recordtransfer/jobs.py
@@ -319,6 +319,28 @@ def send_user_activation_email(new_user: User):
         }
     )
 
+
+@django_rq.job
+def send_user_account_updated(user_updated: User, context_vars: dict):
+    """ Send a notice that the user's account has been updated.
+
+    Args:
+        user_updated (User): The user whose account was updated.
+        context_vars (dict): Template context variables.
+    """
+
+    domain = Site.objects.get_current().domain
+    from_email = '{0}@{1}'.format(DO_NOT_REPLY_USERNAME, domain)
+
+    send_mail_with_logs(
+        recipients=[user_updated.email],
+        from_email=from_email,
+        subject=context_vars['subject'],
+        template_name='recordtransfer/email/account_updated.html',
+        context=context_vars
+    )
+
+
 def send_mail_with_logs(recipients: list, from_email: str, subject, template_name: str,
                         context: dict):
     try:

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/email/account_updated.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/email/account_updated.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html style="
+    font-family: 'Segoe UI', Frutiger, 'Frutiger Linotype', 'Dejavu Sans', 'Helvetica Neue', Arial, sans-serif;
+    margin: 0;">
+    <body style="
+        margin: 0;">
+        <div style="
+            color: #333333;
+            font-size: 20pt;
+            padding: 6px 20px;
+            background-color: #eeeeee;
+            margin-bottom: 15px;">
+            {{ subject }}
+        </div>
+        <div style="
+            padding: 0px 20px;">
+            <div>
+                <p>Your {{ changed_item }} for the NCTR Record Transfer Portal has been {{ changed_status }}.</p>
+                {% if changed_list %}
+                <p>The following changes have been made to your account.</p>
+                <ul>
+                    {% for change in changed_list %}
+                    <li>{{ change }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+                </div>
+            <div style="
+                font-size: 10pt;">
+                <i>This email address is not monitored, do not reply to this message.</i>
+            </div>
+            <div style="
+                font-size: 10pt;">
+                <i>If you do not want to receive these emails anymore, click this link.</i>
+            </div>
+        </div>
+    </body>
+</html>

--- a/bagitobjecttransfer/recordtransfer/templates/recordtransfer/email/account_updated.html
+++ b/bagitobjecttransfer/recordtransfer/templates/recordtransfer/email/account_updated.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{% load i18n %}
 <html style="
     font-family: 'Segoe UI', Frutiger, 'Frutiger Linotype', 'Dejavu Sans', 'Helvetica Neue', Arial, sans-serif;
     margin: 0;">
@@ -15,9 +16,9 @@
         <div style="
             padding: 0px 20px;">
             <div>
-                <p>Your {{ changed_item }} for the NCTR Record Transfer Portal has been {{ changed_status }}.</p>
+                <p>{% blocktranslate %}Your {{ changed_item }} for the NCTR Record Transfer Portal has been {{ changed_status }}.{% endblocktranslate %}</p>
                 {% if changed_list %}
-                <p>The following changes have been made to your account.</p>
+                <p>{% translate "The following changes have been made to your account." %}</p>
                 <ul>
                     {% for change in changed_list %}
                     <li>{{ change }}</li>
@@ -27,11 +28,11 @@
                 </div>
             <div style="
                 font-size: 10pt;">
-                <i>This email address is not monitored, do not reply to this message.</i>
+                <i>{% translate "This email address is not monitored, do not reply to this message." %}</i>
             </div>
             <div style="
                 font-size: 10pt;">
-                <i>If you do not want to receive these emails anymore, click this link.</i>
+                <i>{% translate "If you do not want to receive these emails anymore, click this link." %}</i>
             </div>
         </div>
     </body>


### PR DESCRIPTION
Resolves #31 

Not sure if there is a better way to intercept the password change, my theory based on the [method in Admin](https://github.com/django/django/blob/main/django/contrib/auth/admin.py#L129-L190) is if it raised an exception that would skip the message stuff and immediately raise up to the top. Otherwise we return the form or redirect response once we have (or have not) sent the email. 